### PR TITLE
feat(destinations): add /register endpoint and API-key gate; tidy places

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,6 @@ Base.metadata.create_all(bind=engine)  # ★ 初回にSQLiteへテーブル作�
 app.include_router(places_router)
 app.include_router(destinations_router)
 
-@app.get("/health")
-def health():
-    return {"status": "ok"}
+# @app.get("/health")
+# def health():
+#     return {"status": "ok"}

--- a/backend/app/routes/destinations.py
+++ b/backend/app/routes/destinations.py
@@ -1,19 +1,32 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, HTTPException, Header
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from typing import List
-
+import os
 from app.db.database import get_db
 from app.db import models
 from app.schemas.destination import DestinationCreate, DestinationRead
+from app.services import places as svc
 
 router = APIRouter(prefix="/destinations", tags=["destinations"])
 
-@router.post("/", response_model=DestinationRead)
+# --- 簡易APIキー保護（.env に ADMIN_API_KEY がある時だけ有効化）---
+ADMIN_API_KEY = os.getenv("ADMIN_API_KEY", "").strip()
+
+def maybe_require_admin(x_api_key: str = Header(default="")):
+    """ADMIN_API_KEY が設定されている場合のみ、X-API-Key ヘッダをチェック"""
+    if ADMIN_API_KEY and x_api_key != ADMIN_API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+@router.post("/", response_model=DestinationRead, dependencies=[Depends(maybe_require_admin)], status_code=201)
 def create_destination(payload: DestinationCreate, db: Session = Depends(get_db)):
     obj = models.Destination(
-        place_id=payload.placeId, name=payload.name, address=payload.address,
-        lat=payload.lat, lng=payload.lng
+        place_id=payload.placeId,
+        name=payload.name,
+        address=payload.address,
+        lat=payload.lat,
+        lng=payload.lng,
     )
     db.add(obj)
     try:
@@ -24,8 +37,53 @@ def create_destination(payload: DestinationCreate, db: Session = Depends(get_db)
         raise HTTPException(status_code=409, detail="Destination already exists (place_id)")
     db.refresh(obj)
     return DestinationRead(
-        id=obj.id, placeId=obj.place_id, name=obj.name, address=obj.address, lat=obj.lat, lng=obj.lng
+        id=obj.id,
+        placeId=obj.place_id,
+        name=obj.name,
+        address=obj.address,
+        lat=obj.lat,
+        lng=obj.lng,
     )
+
+# --------------- UX簡略化：place_id だけで登録する -------------------
+@router.post("/register", response_model=DestinationRead, dependencies=[Depends(maybe_require_admin)], status_code=201)
+async def register_from_place_id(
+    place_id: str = Query(..., description="Google Place ID"),
+    db: Session = Depends(get_db),
+):
+    """
+    place_id だけ受け取り、サーバー側で Places Details を取得して保存する。
+    フロントは details 結果を組み立てる必要なし。
+    """
+    data = await svc.details(place_id)
+    if not data or "geometry" not in data or "location" not in data["geometry"]:
+        raise HTTPException(status_code=404, detail="Place details not found")
+
+    obj = models.Destination(
+        place_id=data["place_id"],
+        name=data.get("name", ""),
+        address=data.get("formatted_address", ""),
+        lat=data["geometry"]["location"]["lat"],
+        lng=data["geometry"]["location"]["lng"],
+    )
+    db.add(obj)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        # 既に登録済み
+        raise HTTPException(status_code=409, detail="Destination already exists (place_id)")
+    db.refresh(obj)
+    return DestinationRead(
+        id=obj.id,
+        placeId=obj.place_id,
+        name=obj.name,
+        address=obj.address,
+        lat=obj.lat,
+        lng=obj.lng,
+    )
+
+# ------------------ 保存済み一覧（ページング対応） -------------------
 
 @router.get("/", response_model=List[DestinationRead])
 def list_destinations(
@@ -35,6 +93,13 @@ def list_destinations(
 ):
     rows = db.query(models.Destination).offset(skip).limit(limit).all()
     return [
-        DestinationRead(id=r.id, placeId=r.place_id, name=r.name, address=r.address, lat=r.lat, lng=r.lng)
+        DestinationRead(
+            id=r.id,
+            placeId=r.place_id,
+            name=r.name,
+            address=r.address,
+            lat=r.lat,
+            lng=r.lng,
+        )
         for r in rows
     ]

--- a/backend/app/routes/places.py
+++ b/backend/app/routes/places.py
@@ -3,18 +3,18 @@ from app.services import places as svc
 
 router = APIRouter(prefix="/places", tags=["places"])
 
-MOCK_PREDS = [
-    {"description": "清水寺, 京都", "place_id": "mock_kiyomizu"},
-    {"description": "清水寺 成就院", "place_id": "mock_jojuin"},
-    {"description": "清水寺 奥の院", "place_id": "mock_okunoin"},
-]
+# MOCK_PREDS = [
+#     {"description": "清水寺, 京都", "place_id": "mock_kiyomizu"},
+#     {"description": "清水寺 成就院", "place_id": "mock_jojuin"},
+#     {"description": "清水寺 奥の院", "place_id": "mock_okunoin"},
+# ]
 
-MOCK_DETAIL = {
-    "place_id": "mock_kiyomizu",
-    "name": "清水寺",
-    "formatted_address": "京都府京都市東山区清水",
-    "geometry": {"location": {"lat": 34.994856, "lng": 135.785046}},
-}
+# MOCK_DETAIL = {
+#     "place_id": "mock_kiyomizu",
+#     "name": "清水寺",
+#     "formatted_address": "京都府京都市東山区清水",
+#     "geometry": {"location": {"lat": 34.994856, "lng": 135.785046}},
+# }
 @router.get("/predictions")
 async def predictions(input: str = Query(..., min_length=1), limit: int = 3):
     try:


### PR DESCRIPTION
主な変更点
新規エンドポイント /destinations/register 実装

place_id をクエリパラメータで受け取り、サーバ側で Google Places Details API を実行。

name / address / lat / lng を取得し、DBへ保存。

既存の POST /destinations は互換性のため残置。

簡易APIキー認証の導入

.env に ADMIN_API_KEY が設定されている場合のみ有効化。

X-API-Key ヘッダの一致を確認し、不一致または未指定時は 401 Unauthorized を返す。

places モジュールの整理

不要コメントやデバッグ用コードを削除し、整形。